### PR TITLE
deprecate python 3.7 support

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,10 +20,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.8
     - pip
   run:
-    - python >=3.6
+    - python >=3.8
     - requests >=2.22.0
     - requests-toolbelt >=0.9.1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   # Note: --no-deps is currently required due to https://github.com/conda/conda-build/issues/3254
   # Once resolved, it should be removed.
   script: {{ PYTHON }} -m pip install . --no-deps -vv


### PR DESCRIPTION
`python-gitlab` package support for python `3.7` was removed as of version `4.0`. 

https://python-gitlab.readthedocs.io/en/stable/changelog.html#v4-0-0-2023-10-17

Usage of version `4.1.1` with python `3.7` results in import errors:

```bash
❯ python -c "from gitlab import _backends, utils"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/mobileye/harelw/.conda/envs/mxp-bye/lib/python3.7/site-packages/gitlab/__init__.py", line 30, in <module>
    from gitlab.client import Gitlab, GitlabList  # noqa: F401
  File "/home/mobileye/harelw/.conda/envs/mxp-bye/lib/python3.7/site-packages/gitlab/client.py", line 26, in <module>
    from gitlab import _backends, utils
  File "/home/mobileye/harelw/.conda/envs/mxp-bye/lib/python3.7/site-packages/gitlab/utils.py", line 7, in <module>
    from typing import Any, Callable, Dict, Iterator, Literal, Optional, Tuple, Type, Union
```

`python-gitlab` conda package recipe is not up to date with this deprecation.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
